### PR TITLE
Handles exceptions raised by coroutine made in shutdown waits for

### DIFF
--- a/aiorun.py
+++ b/aiorun.py
@@ -67,7 +67,7 @@ def shutdown_waits_for(coro, loop=None):
                 fut.set_result(result)
             except asyncio.InvalidStateError:
                 logger.warning('Failed to set result.')
-        except CancelledError as e:
+        except Exception as e:
             fut.set_exception(e)
 
     new_coro = coro_proxy()  # We'll taskify this one instead of coro.


### PR DESCRIPTION
Because shutdown_waits_for creates a new task as a proxy for the coroutine, it must handle all exception types and not just CancelledErrors. If this isn't included, when an exception is raised in coro it isn't handled and an error you get this message: 'Task exception was never retrieved'.