### PR TITLE
KeyError can be raised in aiorun's custom_exception_handler

### DIFF
--- a/aiorun.py
+++ b/aiorun.py
@@ -184,7 +184,7 @@ def run(
     def custom_exception_handler(loop, context: dict):
         """See: https://docs.python.org/3/library/asyncio-eventloop.html#error-handling-api"""
         nonlocal pending_exception_to_raise
-        pending_exception_to_raise = context["exception"]
+        pending_exception_to_raise = context.get("exception")
         logger.error("Unhandled exception; stopping loop.")
         loop.stop()
 

--- a/tests/test_stop_on_errors.py
+++ b/tests/test_stop_on_errors.py
@@ -26,3 +26,40 @@ def test_exc_stop():
     print(excinfo.traceback)
     assert "Stops the loop" in str(excinfo.value)
     assert all(t.cancelled for t in created_tasks)
+
+
+class _TestException(Exception):
+    pass
+
+
+@pytest.mark.parametrize('context, raised_exc', [
+    (
+        {'message': 'test error'},
+        None,
+    ),
+    (
+        {'message': 'test error', 'exception': _TestException('test error')},
+        _TestException,
+    ),
+])
+def test_call_exception_handler(context, raised_exc):
+    """Test when loop's exception handler was called with custom context"""
+    created_tasks = []
+
+    async def background_task():
+        await asyncio.sleep(2)
+
+    async def main():
+        loop = asyncio.get_event_loop()
+        created_tasks.extend(loop.create_task(background_task()) for _ in range(5))
+        await asyncio.sleep(0.1)
+        loop.call_exception_handler(context=context)
+
+    if raised_exc is not None:
+        with pytest.raises(raised_exc) as excinfo:
+            run(main(), stop_on_unhandled_errors=True)
+            assert "test error" in str(excinfo.value)
+    else:
+        run(main(), stop_on_unhandled_errors=True)
+
+    assert all(t.cancelled for t in created_tasks)


### PR DESCRIPTION
Fixed `KeyError` when loop's exception handler was called with context without exception key.
https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_exception_handler