### PR TITLE
Private function to collect early signals

### DIFF
--- a/aiorun.py
+++ b/aiorun.py
@@ -158,8 +158,8 @@ def run(
     # Signal events that occur before we've had time to set up. Such events
     # will accumulate in this list.
     early_events = []
-    func = partial(_shutdown_handler_queued, events=[])
-    _set_signal_handlers(_shutdown_handler_queued)
+    func = partial(_shutdown_handler_queued, events=early_events)
+    _set_signal_handlers(func)
 
     logger.debug("Entering run()")
     # Disable default signal handling ASAP
@@ -343,7 +343,7 @@ def _signal_wrapper(sig, frame, loop: asyncio.AbstractEventLoop, actual_handler)
     loop.call_soon_threadsafe(actual_handler, loop)
 
 
-def _shutdown_handler_queued(sig, frame, events: List):
+def _shutdown_handler_queued(sig, frame, *, events: List):
     events.append((sig, frame))
 
 

--- a/aiorun.py
+++ b/aiorun.py
@@ -364,12 +364,23 @@ def _set_signal_handlers(threadsafe_func):
         signal.signal(signal.SIGINT, threadsafe_func)
 
 
+def _signal_ignore(sig, frame):
+    # Python 3.6 still suffers from "TypeError: int is not callable" if
+    # SIG_IGN is used. When we drop 3.6 out of the matrix, this can change
+    # but until then it looks like a do-nothing handler is our best bet.
+    #
+    # See:
+    # - https://bugs.python.org/issue39169
+    # - https://bugs.python.org/issue23395
+    pass
+
+
 def _clear_signal_handlers():
     if WINDOWS:  # pragma: no cover
         # These calls to signal.signal can only be called from the main
         # thread.
-        signal.signal(signal.SIGBREAK, signal.SIG_IGN)
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGBREAK, _signal_ignore)
+        signal.signal(signal.SIGINT, _signal_ignore)
     else:
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, _signal_ignore)
+        signal.signal(signal.SIGTERM, _signal_ignore)


### PR DESCRIPTION
So this is basically the following idea:

- It takes us some time to get to the point where we add signal handlers to the event loop
- "What happens if we receive a signal before that?"
- Idea: very early on, we can set up a signal handler (that is not part of the async stuff, just using `signal.signal`), and we can collect any signals that come in...
- ...and then later when we finally set up the signal handlers on the event loop, we can replay the previously-collected signals, if any, that were received earlier during startup.

I don't know if this idea is any good, and I'm approaching a conclusion that it is low value.  Certainly too low value in exchange for the additional code that has to go in to support it. We'd still have the same problem for the time period before `signal.signal` is set, so what would really be saved? Not very much. So I am very likely going to close this PR at some point.