### PR TITLE
Use ProactorEventLoop on Windows

### DIFF
--- a/aiorun.py
+++ b/aiorun.py
@@ -174,8 +174,15 @@ def run(
             asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         else:
             asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
-
-        loop = asyncio.new_event_loop()
+        
+        if WINDOWS:  # pragma: no cover
+            # In python 3.8+ ProactorEventLoop is the default event loop on
+            # windows. It is explicitly set here so this event loop is used on python
+            # versions below 3.8.
+            loop = asyncio.ProactorEventLoop()
+        else:
+            loop = asyncio.new_event_loop()
+        
         asyncio.set_event_loop(loop)
 
     if loop and loop.get_exception_handler() and stop_on_unhandled_errors:


### PR DESCRIPTION
This is a minor PR that ensures the ProactorEventLoop is used on windows. This is the default event loop on windows for python 3.8+ (see [here](https://docs.python.org/3.8/library/asyncio-eventloop.html#event-loop-implementations)) so it follows this should be set explicitly to ensure this event loop is also used on python versions below 3.8 that use aiorun