### PR TITLE
Log the message and exception when stopping the loop

### DIFF
--- a/aiorun.py
+++ b/aiorun.py
@@ -191,7 +191,11 @@ def run(
         """See: https://docs.python.org/3/library/asyncio-eventloop.html#error-handling-api"""
         nonlocal pending_exception_to_raise
         pending_exception_to_raise = context.get("exception")
-        logger.error("Unhandled exception; stopping loop.")
+        logger.error(
+            "Unhandled exception; stopping loop: %r",
+            context.get("message"),
+            exc_info=pending_exception_to_raise
+        )
         loop.stop()
 
     if stop_on_unhandled_errors:


### PR DESCRIPTION
`message` should always be present and may help to understand why the loop was stopped; `exception` is more likely to be helpful but is not always included. If another exception occurs while the loop is stopping, `pending_exception_to_raise` might never actually get raised.

Closes #56.