### PR TITLE
Remove critical log

### DIFF
--- a/aiorun.py
+++ b/aiorun.py
@@ -365,7 +365,7 @@ def _shutdown_handler(loop):
     logger.debug("Entering shutdown handler")
     loop = loop or get_event_loop()
 
-    logger.critical("Stopping the loop")
+    logger.warning("Stopping the loop")
     loop.stop()
 
 


### PR DESCRIPTION
Stopping the loop is a perfectly normal event (especially in environments like Kubernetes).

So it shouldn't trigger a critical log. When you use libraries like Sentry-sdk, it's super annoying.