### PR TITLE
refactor: remove unnecessary `do_not_cancel` logic

### DIFF
--- a/tests/test_stop_on_errors.py
+++ b/tests/test_stop_on_errors.py
@@ -92,7 +92,7 @@ def test_stop_must_be_obeyed(caplog):
 
     print(excinfo.value)
     print(excinfo.traceback)
-    assert "tasks were cancelled but refused to exit after 2.0 seconds" in caplog.text
+    assert "tasks refused to exit after 2.0 seconds" in caplog.text
     assert "Stops the loop" in str(excinfo.value)
     assert all(t.cancelled for t in created_tasks)
 


### PR DESCRIPTION
`do_not_cancel` was used to keep track of tasks that should not be canceled vs. tasks that should during shutdown phase. However, this separation had no real effect.

- Remove `do_not_cancel` and associated separation logic from "cancelable" tasks.
- Perform simple `if t._coro not in _DO_NOT_CANCEL_COROS` check before cancelling as seen [here](https://github.com/cjrh/aiorun/blob/5923a8df8ae658ab578f733eaf2752fce23c5d52/aiorun.py#L316).
- Make log statement more honest:

  > "During shutdown, the following tasks were cancelled but refused to exit..."

   ^ There are currently no checks on whether or not these tasks are cancelled here, so it cannot be determined that those 
  tasks were "cancelled" by that point. It could rather be the case that all of them were _not_ cancelled.

  Changed to:

  > "During shutdown, the following tasks refused to exit..."