### PR TITLE
Workaround for aiorun triggering stackoverflow in Python

### DIFF
--- a/aiorun.py
+++ b/aiorun.py
@@ -294,7 +294,6 @@ def run(
             # TODO: we don't need access to the coro. We could simply
             # TODO: store the task itself in the weakset.
             if t._coro not in _DO_NOT_CANCEL_COROS:
-                logger.debug("Cancelling task: %s", t)
                 t.cancel()
 
     async def wait_for_cancelled_tasks(timeout):


### PR DESCRIPTION
Under certain circumstances this line https://github.com/cjrh/aiorun/blob/6023e9c61256dcee6e1ab0409c2aefe5487f0f68/aiorun.py#L297  in `aiorun` can trigger the following Python bug https://github.com/python/cpython/issues/93837

The program will crash with a stack overflow error, probably because the call to log the task about the be cancelled will call repr on a task that references itself somehow.

While its not the greatest fix to remove the logging of the individual task to be cancelled (as suggested by this PR), it is just a small inconvenience compared to a hard crash of the application. (I also tried to just log `t.get_name()`, however this was not enough)